### PR TITLE
Fix: pass GITHUB_TOKEN to avoid 401 error (Fixes #<issue-2>)

### DIFF
--- a/.github/workflows/run-analytics.yml
+++ b/.github/workflows/run-analytics.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Run Analytics Action
         uses: ./.github/actions/action
         with:
-          GITHUB_TOKEN: ""
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: eshabalaji
           REPO: code-review-analytics


### PR DESCRIPTION
A 401 in GitHub Actions usually happens if your workflow is trying to access the GitHub API without valid credentials.
[#2 ](url)